### PR TITLE
fix: correct filename parameter in parquet and csv write function

### DIFF
--- a/load_data.R
+++ b/load_data.R
@@ -4,8 +4,8 @@ library(glue)
 plan(multisession(workers = parallel::detectCores() -1))
 
 ### Example
-### Load in 2023-24 PBP Logs
-season <- '2023-24'
+### Load in 2024-25 PBP Logs
+season <- '2024-25'
 file_type <- 'pbp_logs'
 
 files <- dir(glue('{season}/{file_type}'), recursive = T, full.names = T)
@@ -13,5 +13,5 @@ files <- files[!grepl('schedule', files)] ### rm the inventory files
 df_pbp <- future_map_dfr(files, ~read_csv(.x, col_types = cols()))
 
 ### Save out file as CSV (or .parquet)
-write_csv(df_pbp, glue('{file_type}_{pbp_logs}.csv'))
-arrow::write_parquet(df_pbp, glue('{file_type}_{pbp_logs}.parquet'))
+write_csv(df_pbp, glue('{file_type}_{season}.csv'))
+arrow::write_parquet(df_pbp, glue('{file_type}_{season}.parquet'))


### PR DESCRIPTION
- Change variable from `pbp_logs` to `season` in filename template
- Ensure generated parquet files use consistent season-based naming
- Update the season for no reason :)